### PR TITLE
Upgrade to System.Text.Json 8.0.5 to fix the security warning

### DIFF
--- a/App.config
+++ b/App.config
@@ -136,7 +136,11 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="FFmpeg.AutoGen" publicKeyToken="9b7632533a381715" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.2" newVersion="6.0.0.2" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.5" newVersion="8.0.0.5" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/opentuner.csproj
+++ b/opentuner.csproj
@@ -70,8 +70,8 @@
     <Reference Include="CoreAudio, Version=2023.2.28.120, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\CoreAudio.1.27.0\lib\netstandard2.0\CoreAudio.dll</HintPath>
     </Reference>
-    <Reference Include="FFmpeg.AutoGen, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9b7632533a381715, processorArchitecture=MSIL">
-      <HintPath>packages\FFmpeg.AutoGen.6.0.0\lib\netstandard2.0\FFmpeg.AutoGen.dll</HintPath>
+    <Reference Include="FFmpeg.AutoGen, Version=6.0.0.2, Culture=neutral, PublicKeyToken=9b7632533a381715, processorArchitecture=MSIL">
+      <HintPath>packages\FFmpeg.AutoGen.6.0.0.2\lib\netstandard2.0\FFmpeg.AutoGen.dll</HintPath>
     </Reference>
     <Reference Include="FlyleafLib, Version=3.7.50.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\FlyleafLib.3.7.50\lib\net472\FlyleafLib.dll</HintPath>
@@ -85,8 +85,8 @@
     <Reference Include="LibVLCSharp.WinForms, Version=3.8.5.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\LibVLCSharp.WinForms.3.8.5\lib\net40\LibVLCSharp.WinForms.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\Microsoft.Bcl.AsyncInterfaces.7.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\Microsoft.Bcl.AsyncInterfaces.8.0.0\lib\net462\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Bcl.HashCode, Version=1.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.Bcl.HashCode.1.1.1\lib\net461\Microsoft.Bcl.HashCode.dll</HintPath>
@@ -133,7 +133,6 @@
     </Reference>
     <Reference Include="SharpGen.Runtime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=a7c0d43f556c6402, processorArchitecture=MSIL">
       <HintPath>packages\SharpGen.Runtime.2.0.0-beta.13\lib\net471\SharpGen.Runtime.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="SharpGen.Runtime.COM, Version=2.0.0.0, Culture=neutral, PublicKeyToken=a7c0d43f556c6402, processorArchitecture=MSIL">
       <HintPath>packages\SharpGen.Runtime.COM.2.0.0-beta.13\lib\net471\SharpGen.Runtime.COM.dll</HintPath>
@@ -176,11 +175,11 @@
     <Reference Include="System.Security.Principal.Windows, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.Security.Principal.Windows.4.7.0\lib\net461\System.Security.Principal.Windows.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Encodings.Web, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.Text.Encodings.Web.7.0.0\lib\net462\System.Text.Encodings.Web.dll</HintPath>
+    <Reference Include="System.Text.Encodings.Web, Version=8.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Text.Encodings.Web.8.0.0\lib\net462\System.Text.Encodings.Web.dll</HintPath>
     </Reference>
-    <Reference Include="System.Text.Json, Version=7.0.0.2, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.Text.Json.7.0.2\lib\net462\System.Text.Json.dll</HintPath>
+    <Reference Include="System.Text.Json, Version=8.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.Text.Json.8.0.5\lib\net462\System.Text.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
@@ -650,6 +649,10 @@
     <Content Include="tv.ico" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>echo %25date%25 %25time%25 &gt; "$(ProjectDir)\Resources\BuildDate.txt"</PreBuildEvent>
+  </PropertyGroup>
+  <Import Project="packages\PolySharp.1.10.0\build\PolySharp.targets" Condition="Exists('packages\PolySharp.1.10.0\build\PolySharp.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
@@ -657,6 +660,7 @@
     <Error Condition="!Exists('packages\PolySharp.1.10.0\build\PolySharp.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\PolySharp.1.10.0\build\PolySharp.targets'))" />
     <Error Condition="!Exists('packages\SharpGen.Runtime.2.0.0-beta.13\build\SharpGen.Runtime.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\SharpGen.Runtime.2.0.0-beta.13\build\SharpGen.Runtime.props'))" />
     <Error Condition="!Exists('packages\SharpGen.Runtime.COM.2.0.0-beta.13\build\SharpGen.Runtime.COM.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\SharpGen.Runtime.COM.2.0.0-beta.13\build\SharpGen.Runtime.COM.props'))" />
+    <Error Condition="!Exists('packages\VideoLAN.LibVLC.Windows.3.0.20\build\VideoLAN.LibVLC.Windows.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\VideoLAN.LibVLC.Windows.3.0.20\build\VideoLAN.LibVLC.Windows.targets'))" />
     <Error Condition="!Exists('packages\Vortice.DirectX.2.4.2\build\Vortice.DirectX.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Vortice.DirectX.2.4.2\build\Vortice.DirectX.props'))" />
     <Error Condition="!Exists('packages\Vortice.D3DCompiler.2.4.2\build\Vortice.D3DCompiler.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Vortice.D3DCompiler.2.4.2\build\Vortice.D3DCompiler.props'))" />
     <Error Condition="!Exists('packages\Vortice.DXGI.2.4.2\build\Vortice.DXGI.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Vortice.DXGI.2.4.2\build\Vortice.DXGI.props'))" />
@@ -665,11 +669,6 @@
     <Error Condition="!Exists('packages\Vortice.DirectComposition.2.4.2\build\Vortice.DirectComposition.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Vortice.DirectComposition.2.4.2\build\Vortice.DirectComposition.props'))" />
     <Error Condition="!Exists('packages\Vortice.MediaFoundation.2.4.2\build\Vortice.MediaFoundation.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Vortice.MediaFoundation.2.4.2\build\Vortice.MediaFoundation.props'))" />
     <Error Condition="!Exists('packages\Vortice.XAudio2.2.4.2\build\Vortice.XAudio2.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Vortice.XAudio2.2.4.2\build\Vortice.XAudio2.props'))" />
-    <Error Condition="!Exists('packages\VideoLAN.LibVLC.Windows.3.0.20\build\VideoLAN.LibVLC.Windows.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\VideoLAN.LibVLC.Windows.3.0.20\build\VideoLAN.LibVLC.Windows.targets'))" />
   </Target>
-  <Import Project="packages\PolySharp.1.10.0\build\PolySharp.targets" Condition="Exists('packages\PolySharp.1.10.0\build\PolySharp.targets')" />
   <Import Project="packages\VideoLAN.LibVLC.Windows.3.0.20\build\VideoLAN.LibVLC.Windows.targets" Condition="Exists('packages\VideoLAN.LibVLC.Windows.3.0.20\build\VideoLAN.LibVLC.Windows.targets')" />
-  <PropertyGroup>
-    <PreBuildEvent>echo %25date%25 %25time%25 &gt; "$(ProjectDir)\Resources\BuildDate.txt"</PreBuildEvent>
-  </PropertyGroup>
 </Project>

--- a/packages.config
+++ b/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CoreAudio" version="1.27.0" targetFramework="net472" />
-  <package id="FFmpeg.AutoGen" version="6.0.0" targetFramework="net472" />
+  <package id="FFmpeg.AutoGen" version="6.0.0.2" targetFramework="net472" />
   <package id="FlyleafLib" version="3.7.50" targetFramework="net472" />
   <package id="LibVLCSharp" version="3.8.5" targetFramework="net472" />
   <package id="LibVLCSharp.WinForms" version="3.8.5" targetFramework="net472" />
-  <package id="Microsoft.Bcl.AsyncInterfaces" version="7.0.0" targetFramework="net472" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="8.0.0" targetFramework="net472" />
   <package id="Microsoft.Bcl.HashCode" version="1.1.1" targetFramework="net472" />
   <package id="Microsoft.Win32.Registry" version="4.7.0" targetFramework="net472" />
   <package id="MQTTnet" version="4.3.3.952" targetFramework="net472" />
@@ -34,8 +34,8 @@
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net472" />
   <package id="System.Security.AccessControl" version="4.7.0" targetFramework="net472" />
   <package id="System.Security.Principal.Windows" version="4.7.0" targetFramework="net472" />
-  <package id="System.Text.Encodings.Web" version="7.0.0" targetFramework="net472" />
-  <package id="System.Text.Json" version="7.0.2" targetFramework="net472" />
+  <package id="System.Text.Encodings.Web" version="8.0.0" targetFramework="net472" />
+  <package id="System.Text.Json" version="8.0.5" targetFramework="net472" />
   <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
   <package id="VideoLAN.LibVLC.Windows" version="3.0.20" targetFramework="net472" />


### PR DESCRIPTION
This commit fixes the security warning of System.Text.Json by using a fixed version and as a result upgrades Microsoft.Bcl.AsyncInterfaces (from 7.0.0 to 8.0.0), System.Text.Encodings.Web (from 7.0.0 to 8.0.0) and FFmpeg.AutoGen (from 6.0.0.0 to 6.0.0.2) as well. While so far nothing seems broken, I can only do very limited testing so it would be nice if you could test for issues as well.